### PR TITLE
ui: faster skateboard animation, edge-to-edge path, bottom-anchored

### DIFF
--- a/bridge-ui/src/components/SkaterBackground.tsx
+++ b/bridge-ui/src/components/SkaterBackground.tsx
@@ -11,7 +11,7 @@ export default function SkaterBackground({ className }: Props) {
     <div
       aria-hidden
       className={clsx(
-        "pointer-events-none fixed inset-x-0 bottom-4 z-0 h-28 sm:h-40 overflow-visible",
+        "pointer-events-none fixed inset-x-0 bottom-0 z-0 h-24 sm:h-36 overflow-visible",
         className
       )}
     >

--- a/bridge-ui/src/styles/globals.css
+++ b/bridge-ui/src/styles/globals.css
@@ -1,10 +1,10 @@
 @keyframes skate {
-  0% { transform: translateX(-10%); }
-  50% { transform: translateX(90%); }
-  100% { transform: translateX(-10%); }
+  0% { transform: translateX(-40%); }
+  50% { transform: translateX(120%); }
+  100% { transform: translateX(-40%); }
 }
 .animate-skate {
-  animation: skate 18s ease-in-out infinite;
+  animation: skate 8s ease-in-out infinite;
 }
 @media (prefers-reduced-motion: reduce) {
   .animate-skate { animation: none; transform: translateX(0); }


### PR DESCRIPTION
# ui: faster skateboard animation, edge-to-edge path, bottom-anchored

## Summary

Minor adjustment to the skateboard animation based on user feedback to make it faster, travel edge-to-edge across the screen, and position closer to the bottom of the viewport.

**Changes:**
- Animation speed: 18s → 8s (2.25x faster)
- Travel path: -10% to 90% → -40% to 120% (wider edge-to-edge movement)
- Vertical position: `bottom-4` → `bottom-0` (anchored to very bottom)
- Container height: slightly reduced for better proportions

## Review & Testing Checklist for Human

- [ ] **Visual verification**: Check animation looks smooth and natural on both desktop and mobile
- [ ] **Performance check**: Ensure faster animation doesn't cause stuttering or performance issues
- [ ] **Accessibility**: Verify `prefers-reduced-motion` still properly disables animation

**Recommended Test Plan:**
1. Load the page on desktop and mobile
2. Watch the skateboard animation for a full cycle 
3. Test with reduced-motion browser settings enabled

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    SkaterBg["src/components/<br/>SkaterBackground.tsx"]:::minor-edit
    GlobalCSS["src/styles/<br/>globals.css"]:::minor-edit
    
    SkaterBg --> GlobalCSS
    
    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit  
        L3["Context/No Edit"]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

This is a very low-risk change responding to user feedback about animation speed and positioning. The skateboard will now move faster and travel the full width of the screen, briefly disappearing behind the widget as intended.

**Session Info:**
- Requested by: Til Jordan (@tiljrd)
- Devin session: https://app.devin.ai/sessions/721739cc826945c180ffeffb771fdd98