### PR TITLE
fix(balances): correct OP/ARB balance reads via chainId override

### DIFF
--- a/bridge-ui/src/components/BalanceBadge.tsx
+++ b/bridge-ui/src/components/BalanceBadge.tsx
@@ -1,6 +1,7 @@
 import { UnifiedRegistry, ChainKey } from "@config/types";
 import { useTokenBalance } from "../hooks/useTokenBalance";
 import { getDecimals, getTokenAddressForBalance } from "@lib/tokenAddressResolver";
+import { chainKeyToId } from "@lib/chainIds";
 
 export default function BalanceBadge({
   registry,
@@ -15,7 +16,8 @@ export default function BalanceBadge({
   const address = getTokenAddressForBalance(registry, token, origin);
   const { balance, isConnected } = useTokenBalance({
     tokenAddress: (address as any) || null,
-    decimals
+    decimals,
+    chainIdOverride: chainKeyToId[origin]
   });
 
   if (!isConnected) {

--- a/bridge-ui/src/components/BridgeSelector.tsx
+++ b/bridge-ui/src/components/BridgeSelector.tsx
@@ -7,6 +7,7 @@ import TokenBadge from "./ui/TokenBadge";
 import ChainSelect from "./ui/ChainSelect";
 import { useTokenBalance } from "../hooks/useTokenBalance";
 import { getDecimals, getTokenAddressForBalance } from "@lib/tokenAddressResolver";
+import { chainKeyToId } from "@lib/chainIds";
 
 type Selection = {
   token: string;
@@ -40,7 +41,8 @@ export default function BridgeSelector({
     registry.tokens.find((t) => t.symbol.toLowerCase() === "pyusd")?.symbol || "PYUSD";
   const decimals = getDecimals(registry, pyusdSymbol);
   const tokenAddr = getTokenAddressForBalance(registry, pyusdSymbol, selection.origin);
-  const { raw } = useTokenBalance({ tokenAddress: (tokenAddr as any) || null, decimals });
+  const chainIdOverride = chainKeyToId[selection.origin];
+  const { raw } = useTokenBalance({ tokenAddress: (tokenAddr as any) || null, decimals, chainIdOverride });
 
   function update(partial: Partial<Selection>) {
     onChange({ ...selection, ...partial });

--- a/bridge-ui/src/lib/chainIds.ts
+++ b/bridge-ui/src/lib/chainIds.ts
@@ -1,0 +1,7 @@
+import { mainnet, optimism, arbitrum } from "wagmi/chains";
+
+export const chainKeyToId: Record<string, number> = {
+  ethereum: mainnet.id,
+  optimism: optimism.id,
+  arbitrum: arbitrum.id
+};


### PR DESCRIPTION
# fix(balances): correct OP/ARB balance reads via chainId override

## Summary

Fixes Optimism and Arbitrum balance display by ensuring balance queries target the selected origin chain's RPC, not the connected wallet's current chain. Previously, if a user was connected to Ethereum but selected Optimism as the "From" chain, the balance would incorrectly show their Ethereum PYUSD balance instead of their Optimism balance.

**Root cause:** The `useTokenBalance` hook was using `useChainId()` from wagmi, which returns the connected wallet's current chain, not the UI-selected chain.

**Solution:** Pass `chainIdOverride` parameter to force balance reads on the correct chain.

## Review & Testing Checklist for Human

- [ ] **Test balance display accuracy**: Connect wallet to Ethereum, then switch "From" chain to Optimism/Arbitrum in UI - verify balance shows correctly for selected chain, not connected chain
- [ ] **Test Max button functionality**: Verify Max button populates correct balance amount when origin chain differs from connected wallet chain  
- [ ] **Verify chain ID mapping**: Confirm `chainKeyToId` mapping in `src/lib/chainIds.ts` matches actual chain IDs (mainnet: 1, optimism: 10, arbitrum: 42161)
- [ ] **Cross-chain testing**: Test all combinations of ETH/OP/ARB as origin chains to ensure no regressions

## Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    chainIds["src/lib/chainIds.ts<br/>(ChainKey → chainId mapping)"]:::major-edit
    useTokenBalance["hooks/useTokenBalance.ts<br/>(accepts chainIdOverride)"]:::context
    BalanceBadge["components/BalanceBadge.tsx<br/>(shows balance in UI)"]:::minor-edit  
    BridgeSelector["components/BridgeSelector.tsx<br/>(Max button logic)"]:::minor-edit
    
    chainIds --> BalanceBadge
    chainIds --> BridgeSelector
    BalanceBadge --> useTokenBalance
    BridgeSelector --> useTokenBalance
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end

classDef major-edit fill:#90EE90
classDef minor-edit fill:#87CEEB
classDef context fill:#FFFFFF
```

## Notes

- Changes maintain registry-driven address resolution via `@lib/tokenAddressResolver`
- wagmi config in `_app.tsx` already supports ETH/OP/ARB chains, so chainIdOverride should work
- **⚠️ Not locally tested** due to missing UI component imports - human testing is critical
- Built on top of previous registry centralization work from earlier PRs

---
**Link to Devin run:** https://app.devin.ai/sessions/721739cc826945c180ffeffb771fdd98  
**Requested by:** Til Jordan (@tiljrd)