### PR TITLE
fix(balances): correct OP/ARB token resolution in tokenAddressResolver

### DIFF
--- a/bridge-ui/src/lib/tokenAddressResolver.ts
+++ b/bridge-ui/src/lib/tokenAddressResolver.ts
@@ -9,26 +9,26 @@ export function getTokenAddressForBalance(
   symbol: string,
   chain: ChainKey
 ): string | null {
+  const lower = symbol.toLowerCase();
+
   const oft = reg.routes.find(
-    (r): r is Extract<RouteConfig, { bridgeType: "OFT" }> =>
-      r.bridgeType === "OFT" && r.oft.token.toLowerCase() === symbol.toLowerCase()
+    (r): r is Extract<RouteConfig, { bridgeType: "OFT" }> => r.bridgeType === "OFT" && r.oft.token.toLowerCase() === lower
   );
-  if (oft) {
-    const addr = (oft as any)?.oft?.oft?.[chain] as string | undefined;
-    return addr ?? null;
+  const oftAddr = (oft as any)?.oft?.oft?.[chain] as string | undefined;
+  if (oftAddr) {
+    return oftAddr;
   }
 
   const hwr = reg.routes.find(
-    (r): r is Extract<RouteConfig, { bridgeType: "HWR" }> =>
-      r.bridgeType === "HWR" && r.hwr.token.toLowerCase() === symbol.toLowerCase()
+    (r): r is Extract<RouteConfig, { bridgeType: "HWR" }> => r.bridgeType === "HWR" && r.hwr.token.toLowerCase() === lower
   );
   if (hwr) {
     if (chain === "optimism") {
       const synth = (hwr as any)?.hwr?.syntheticToken?.optimism as string | undefined;
-      return synth ?? null;
+      if (synth) return synth;
     }
     const coll = (hwr as any)?.hwr?.collateralTokens?.[chain] as string | undefined;
-    return coll ?? null;
+    if (coll) return coll;
   }
 
   return null;


### PR DESCRIPTION
# fix(balances): correct OP/ARB token resolution in tokenAddressResolver

## Summary

Fixes Optimism and Arbitrum balance display by correcting the token address resolution logic in `getTokenAddressForBalance`. Previously, the function would return `null` for Optimism when an OFT route existed but didn't have an Optimism entry, preventing fallback to the HWR synthetic token address. This caused balance queries to fail and the Max button to not work correctly.

**Root cause:** The resolver was returning `null` immediately if an OFT route was found but didn't contain the requested chain, instead of falling back to HWR address resolution.

**Solution:** Updated logic to only return an OFT address if it actually exists for the requested chain, otherwise fall back to HWR resolution (synthetic token for Optimism, collateral tokens for other chains).

## Review & Testing Checklist for Human

- [ ] **Test balance display for all chains**: Connect wallet and verify balance shows correctly when selecting Ethereum, Optimism, and Arbitrum as origin chains
- [ ] **Verify Max button functionality**: Confirm Max button populates the correct balance amount for each origin chain selection
- [ ] **Cross-chain balance accuracy**: Switch between different origin chains and verify each shows the correct token balance (not the connected wallet's chain balance)
- [ ] **No Ethereum regressions**: Ensure existing Ethereum balance functionality still works correctly after the resolver changes

**Recommended test plan**: Connect wallet to any chain, then use the UI to switch between ETH/OP/ARB as origin chains and verify balance display and Max button behavior matches the actual token balances on each respective chain.

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    registry["public/registry.artifact.json<br/>(OFT + HWR route configs)"]:::context
    resolver["src/lib/tokenAddressResolver.ts<br/>(getTokenAddressForBalance)"]:::major-edit
    BalanceBadge["src/components/BalanceBadge.tsx<br/>(displays balance in UI)"]:::context
    BridgeSelector["src/components/BridgeSelector.tsx<br/>(Max button logic)"]:::context
    useTokenBalance["src/hooks/useTokenBalance.ts<br/>(wagmi balance hook)"]:::context
    chainIds["src/lib/chainIds.ts<br/>(ChainKey to chainId mapping)"]:::context
    
    registry --> resolver
    resolver --> BalanceBadge
    resolver --> BridgeSelector
    BalanceBadge --> useTokenBalance
    BridgeSelector --> useTokenBalance
    chainIds --> BalanceBadge
    chainIds --> BridgeSelector
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit
        L3[Context/No Edit]:::context
    end

classDef major-edit fill:#90EE90
classDef minor-edit fill:#87CEEB
classDef context fill:#FFFFFF
```

### Notes

- Changes maintain the registry as single source of truth for token addresses
- Built on top of previous chainId override work from PR #10 
- ⚠️ **Limited local testing** due to environment setup - human verification is critical for balance accuracy
- The resolver now properly handles the hybrid OFT/HWR token deployment where Optimism uses HWR synthetic tokens but Arbitrum/Ethereum use OFT tokens

---
**Link to Devin run:** https://app.devin.ai/sessions/721739cc826945c180ffeffb771fdd98  
**Requested by:** Til Jordan (@tiljrd)