### PR TITLE
LayerZero v2: fix PYUSD OFT quoteSend/send (ETH↔ARB), wire adapters, add LZ v2 options

### DIFF
--- a/bridge-ui/package-lock.json
+++ b/bridge-ui/package-lock.json
@@ -12,6 +12,7 @@
         "@hyperlane-xyz/sdk": "^16.2.0",
         "@hyperlane-xyz/utils": "^16.2.0",
         "@hyperlane-xyz/widgets": "^16.2.0",
+        "@layerzerolabs/lz-v2-utilities": "^3.0.125",
         "@rainbow-me/rainbowkit": "^2.2.0",
         "@tanstack/query-core": "^5.85.3",
         "@tanstack/react-query": "^5.85.3",
@@ -6675,6 +6676,22 @@
         "@keplr-wallet/types": "0.12.28",
         "big-integer": "^1.6.48",
         "utility-types": "^3.10.0"
+      }
+    },
+    "node_modules/@layerzerolabs/lz-v2-utilities": {
+      "version": "3.0.125",
+      "resolved": "https://registry.npmjs.org/@layerzerolabs/lz-v2-utilities/-/lz-v2-utilities-3.0.125.tgz",
+      "integrity": "sha512-dyHiy+tKl8l3F2xxM3rhME24Y5YXo3wG1tCL9OumQVdwIq4dALD0zWDs9oz6+WQEs1JL3Nq/alxAU2oxCRZFYQ==",
+      "license": "BUSL-1.1",
+      "dependencies": {
+        "@ethersproject/abi": "^5.8.0",
+        "@ethersproject/address": "^5.8.0",
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/keccak256": "^5.8.0",
+        "@ethersproject/solidity": "^5.8.0",
+        "bs58": "^5.0.0",
+        "tiny-invariant": "^1.3.1"
       }
     },
     "node_modules/@lit-labs/ssr-dom-shim": {
@@ -30482,6 +30499,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
     },
     "node_modules/tiny-secp256k1": {
       "version": "1.1.7",

--- a/bridge-ui/package.json
+++ b/bridge-ui/package.json
@@ -15,6 +15,7 @@
     "@hyperlane-xyz/sdk": "^16.2.0",
     "@hyperlane-xyz/utils": "^16.2.0",
     "@hyperlane-xyz/widgets": "^16.2.0",
+    "@layerzerolabs/lz-v2-utilities": "^3.0.125",
     "@rainbow-me/rainbowkit": "^2.2.0",
     "@tanstack/query-core": "^5.85.3",
     "@tanstack/react-query": "^5.85.3",

--- a/bridge-ui/public/registry.artifact.json
+++ b/bridge-ui/public/registry.artifact.json
@@ -38,8 +38,8 @@
       "oft": {
         "token": "PYUSD",
         "oft": {
-          "ethereum": "0x6c3ea9036406852006290770BEdFcAbA0e23A0e8",
-          "arbitrum": "0x46850aD61C2B7d64d08c9C754F45254596696984"
+          "ethereum": "0xa2C323fE5A74aDffAd2bf3E007E36bb029606444",
+          "arbitrum": "0xFaB5891ED867a1195303251912013b92c4fc3a1D"
         },
         "endpointIds": {
           "ethereum": 30101,

--- a/bridge-ui/scripts/checkBalances.mjs
+++ b/bridge-ui/scripts/checkBalances.mjs
@@ -1,0 +1,36 @@
+import { createPublicClient, http } from "viem";
+import { mainnet, arbitrum } from "viem/chains";
+
+const ERC20_ABI = [
+  { type: "function", name: "balanceOf", stateMutability: "view", inputs: [{ type: "address" }], outputs: [{ type: "uint256" }] },
+  { type: "function", name: "decimals", stateMutability: "view", inputs: [], outputs: [{ type: "uint8" }] },
+  { type: "function", name: "symbol", stateMutability: "view", inputs: [], outputs: [{ type: "string" }] }
+];
+
+async function main() {
+  const addr = process.env.ADDR || "0x84C69E428bC8f2f1bc359F9f1c2a49559df07722";
+  const eth = createPublicClient({ chain: mainnet, transport: http(process.env.ETH_RPC || "https://ethereum.publicnode.com") });
+  const arb = createPublicClient({ chain: arbitrum, transport: http(process.env.ARB_RPC || "https://arb1.arbitrum.io/rpc") });
+  const pyusdEth = "0x6c3ea9036406852006290770BEdFcAbA0e23A0e8";
+  const pyusdArb = "0x46850aD61C2B7d64d08c9C754F45254596696984";
+
+  const [symEth, decEth, balEth] = await Promise.all([
+    eth.readContract({ address: pyusdEth, abi: ERC20_ABI, functionName: "symbol" }),
+    eth.readContract({ address: pyusdEth, abi: ERC20_ABI, functionName: "decimals" }),
+    eth.readContract({ address: pyusdEth, abi: ERC20_ABI, functionName: "balanceOf", args: [addr] })
+  ]);
+  const [symArb, decArb, balArb] = await Promise.all([
+    arb.readContract({ address: pyusdArb, abi: ERC20_ABI, functionName: "symbol" }),
+    arb.readContract({ address: pyusdArb, abi: ERC20_ABI, functionName: "decimals" }),
+    arb.readContract({ address: pyusdArb, abi: ERC20_ABI, functionName: "balanceOf", args: [addr] })
+  ]);
+
+  function fmt(bal, dec) {
+    const s = bal.toString().padStart(Number(dec)+1, "0");
+    return `${s.slice(0, -Number(dec))}.${s.slice(-Number(dec))}`;
+  }
+  console.log(`ETH ${symEth} balance: ${fmt(balEth, decEth)} (dec ${decEth})`);
+  console.log(`ARB ${symArb} balance: ${fmt(balArb, decArb)} (dec ${decArb})`);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/bridge-ui/scripts/sendV2.mjs
+++ b/bridge-ui/scripts/sendV2.mjs
@@ -1,0 +1,145 @@
+import { createPublicClient, createWalletClient, http, padHex, getAddress } from "viem";
+import { mainnet, arbitrum } from "viem/chains";
+import { privateKeyToAccount } from "viem/accounts";
+import { Options } from "@layerzerolabs/lz-v2-utilities";
+
+const ERC20_ABI = [
+  { type: "function", name: "decimals", stateMutability: "view", inputs: [], outputs: [{ type: "uint8" }] },
+  { type: "function", name: "symbol", stateMutability: "view", inputs: [], outputs: [{ type: "string" }] },
+  { type: "function", name: "allowance", stateMutability: "view", inputs: [{ type: "address" }, { type: "address" }], outputs: [{ type: "uint256" }] },
+  { type: "function", name: "approve", stateMutability: "nonpayable", inputs: [{ type: "address" }, { type: "uint256" }], outputs: [{ type: "bool" }] }
+];
+
+const OFT_V2_ABI = [
+  {
+    type: "function",
+    name: "quoteSend",
+    stateMutability: "view",
+    inputs: [
+      {
+        type: "tuple",
+        name: "sendParam",
+        components: [
+          { name: "dstEid", type: "uint32" },
+          { name: "to", type: "bytes32" },
+          { name: "amountLD", type: "uint256" },
+          { name: "minAmountLD", type: "uint256" },
+          { name: "extraOptions", type: "bytes" },
+          { name: "composeMsg", type: "bytes" },
+          { name: "oftCmd", type: "bytes" }
+        ]
+      },
+      { name: "payInLzToken", type: "bool" }
+    ],
+    outputs: [
+      {
+        name: "fee",
+        type: "tuple",
+        components: [
+          { name: "nativeFee", type: "uint256" },
+          { name: "lzTokenFee", type: "uint256" }
+        ]
+      }
+    ]
+  },
+  {
+    type: "function",
+    name: "send",
+    stateMutability: "payable",
+    inputs: [
+      {
+        type: "tuple",
+        name: "sendParam",
+        components: [
+          { name: "dstEid", type: "uint32" },
+          { name: "to", type: "bytes32" },
+          { name: "amountLD", type: "uint256" },
+          { name: "minAmountLD", type: "uint256" },
+          { name: "extraOptions", type: "bytes" },
+          { name: "composeMsg", type: "bytes" },
+          { name: "oftCmd", type: "bytes" }
+        ]
+      },
+      {
+        type: "tuple",
+        name: "fee",
+        components: [
+          { name: "nativeFee", type: "uint256" },
+          { name: "lzTokenFee", type: "uint256" }
+        ]
+      },
+      { name: "refundAddress", type: "address" }
+    ],
+    outputs: [
+      {
+        name: "receipt",
+        type: "tuple",
+        components: [
+          { name: "guid", type: "bytes32" },
+          { name: "nonce", type: "uint64" },
+          { name: "fee", type: "uint256" },
+          { name: "valueSent", type: "uint256" }
+        ]
+      }
+    ]
+  }
+];
+
+const toHexBytes = (b) => (typeof b === "string" && b.startsWith("0x")) ? b : ("0x" + Buffer.from(b).toString("hex"));
+
+async function main() {
+  const origin = (process.env.ORIGIN || "ethereum").toLowerCase();
+  const pk = process.env.DEV_PK || process.env.NEXT_PUBLIC_DEV_PRIVATE_KEY;
+  if (!pk) throw new Error("Set DEV_PK env var with the testing private key");
+  const account = privateKeyToAccount((pk.startsWith("0x") ? pk : `0x${pk}`));
+  const recipient = padHex(getAddress(process.env.RECIPIENT || account.address), { size: 32 });
+
+  let chain, transport, publicClient, walletClient, adapter, token, toEid;
+  if (origin === "ethereum") {
+    chain = mainnet;
+    transport = http(process.env.ETH_RPC || "https://ethereum.publicnode.com");
+    adapter = "0xa2C323fE5A74aDffAd2bf3E007E36bb029606444";
+    token = "0x6c3ea9036406852006290770BEdFcAbA0e23A0e8";
+    toEid = 30110;
+  } else if (origin === "arbitrum") {
+    chain = arbitrum;
+    transport = http(process.env.ARB_RPC || "https://arb1.arbitrum.io/rpc");
+    adapter = "0xFaB5891ED867a1195303251912013b92c4fc3a1D";
+    token = "0x46850aD61C2B7d64d08c9C754F45254596696984";
+    toEid = 30101;
+  } else {
+    throw new Error("Unsupported ORIGIN; use ethereum or arbitrum");
+  }
+
+  publicClient = createPublicClient({ chain, transport });
+  walletClient = createWalletClient({ chain, transport, account });
+
+  const amountLD = BigInt(process.env.AMOUNT_LD || "1000000"); // default 1 PYUSD (6d)
+  const options = toHexBytes(Options.newOptions().addExecutorLzReceiveOption(300_000, 0).toBytes());
+
+  try {
+    const allowance = await publicClient.readContract({ address: token, abi: ERC20_ABI, functionName: "allowance", args: [account.address, adapter] });
+    if (allowance < amountLD) {
+      console.log("Approving adapter to spend PYUSD...");
+      const approveHash = await walletClient.writeContract({ address: token, abi: ERC20_ABI, functionName: "approve", args: [adapter, amountLD] });
+      console.log("approve tx:", approveHash);
+    }
+  } catch (e) {
+    console.log("Allowance/approve step failed or token not standard ERC20 on this chain:", e?.shortMessage || e?.message || e);
+  }
+
+  const sendParam = { dstEid: Number(toEid), to: recipient, amountLD, minAmountLD: amountLD, extraOptions: options, composeMsg: "0x", oftCmd: "0x" };
+  const fee = await publicClient.readContract({ address: adapter, abi: OFT_V2_ABI, functionName: "quoteSend", args: [sendParam, false] });
+  console.log("fee:", fee);
+
+  const receipt = await walletClient.writeContract({
+    address: adapter,
+    abi: OFT_V2_ABI,
+    functionName: "send",
+    args: [sendParam, { nativeFee: fee.nativeFee, lzTokenFee: 0n }, account.address],
+    value: fee.nativeFee > 0n ? fee.nativeFee : undefined
+  });
+  console.log("send tx:", receipt);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });


### PR DESCRIPTION
LayerZero v2: fix PYUSD OFT quoteSend/send (ETH↔ARB), wire adapters, add LZ v2 options

Summary
- Fixed LayerZero integration for PYUSD by switching to LayerZero v2 struct-based ABI for quoteSend/send and passing proper LZ v2 executor options.
- Wired correct OFT adapter addresses and EIDs for Ethereum and Arbitrum.
- Added small helper scripts to quote, send, and check balances for real on-chain tests.

Addresses and EIDs
- ETH OFT Adapter: 0xa2C323fE5A74aDffAd2bf3E007E36bb029606444
- ARB OFT Wrapper: 0xFaB5891ED867a1195303251912013b92c4fc3a1D
- PYUSD (ETH): 0x6c3ea9036406852006290770BEdFcAbA0e23A0e8
- PYUSD (ARB): 0x46850aD61C2B7d64d08c9C754F45254596696984
- LayerZero v2 EIDs: Ethereum = 30101, Arbitrum = 30110

Core changes
- src/lib/oftSend.ts
  - Replace v1-style ABI with v2 struct-based ABI
  - Build SendParam with extraOptions = Options.newOptions().addExecutorLzReceiveOption(300_000, 0).toBytes()
  - Use quoteSend(sendParam, false) and send(sendParam, fee, refundAddress)
  - Improved errors when config is missing/invalid
- public/registry.artifact.json
  - Wire OFT adapter addresses and endpoint IDs
- scripts
  - scripts/sendV2.mjs: minimal ETH↔ARB send (real on-chain)
  - scripts/checkBalances.mjs: check PYUSD balances on both chains

Test evidence (mainnet)
- ETH→ARB
  - quoteSend: { nativeFee: 21677908095871, lzTokenFee: 0 }
  - send tx: 0x8d9b51953d57a12aecdcd8deb855457b5571c6ed9493a876c5e6aac15c78031b
- ARB→ETH
  - quoteSend: { nativeFee: 219235292620222, lzTokenFee: 0 }
  - send attempted with 1 wei of PYUSD; reverted due to 0 PYUSD balance on ARB (expected until inbound arrives)
- Balances:
  - ETH PYUSD: 88.600000
  - ARB PYUSD: 0.000000

How to run locally
- Configure RPCs via env:
  - NEXT_PUBLIC_ETHEREUM_RPC_URL, NEXT_PUBLIC_ARBITRUM_RPC_URL
- Run the UI:
  - npm ci && npm run dev
- Optional test scripts:
  - node scripts/checkBalances.mjs
  - ETH→ARB: DEV_PK=... ORIGIN=ethereum AMOUNT_LD=1000000 node scripts/sendV2.mjs
  - ARB→ETH: DEV_PK=... ORIGIN=arbitrum AMOUNT_LD=1 node scripts/sendV2.mjs

Link to Devin run
- https://app.devin.ai/sessions/4ea980ea4408489ca369322cb3bf212a

Requested by
- Til Jordan (@tiljrd)
