### PR TITLE
bridge-ui: Add dedicated balances field and resolve balances to ERC20 contracts

### DIFF
--- a/bridge-ui/public/registry.artifact.json
+++ b/bridge-ui/public/registry.artifact.json
@@ -25,6 +25,11 @@
         "syntheticToken": {
           "optimism": "0x2A0B01E072b3d68249A2b3666cB90585eC4bd79e"
         },
+        "balances": {
+          "ethereum": "0x6c3ea9036406852006290770BEdFcAbA0e23A0e8",
+          "arbitrum": "0x46850aD61C2B7d64d08c9C754F45254596696984",
+          "optimism": "0x2A0B01E072b3d68249A2b3666cB90585eC4bd79e"
+        },
         "edges": [
           { "from": "ethereum", "to": "optimism" },
           { "from": "arbitrum", "to": "optimism" },

--- a/bridge-ui/src/config/types.ts
+++ b/bridge-ui/src/config/types.ts
@@ -23,6 +23,8 @@ export type HwrTopology = {
   routers: HwrRouterAddresses;
   edges: Array<{ from: ChainKey; to: ChainKey }>; 
   supportsMultiSource: boolean;
+  balances?: Record<ChainKey, string | undefined>;
+
 };
 
 export type OftTokenAddresses = Record<ChainKey, string | undefined>;
@@ -31,6 +33,8 @@ export type OftRoute = {
   token: string;
   oft: OftTokenAddresses;
   endpointIds?: Record<ChainKey, number | undefined>;
+  balances?: Record<ChainKey, string | undefined>;
+
 };
 
 export type RouteConfig =

--- a/bridge-ui/src/lib/tokenAddressResolver.ts
+++ b/bridge-ui/src/lib/tokenAddressResolver.ts
@@ -11,24 +11,27 @@ export function getTokenAddressForBalance(
 ): string | null {
   const lower = symbol.toLowerCase();
 
-  const oft = reg.routes.find(
-    (r): r is Extract<RouteConfig, { bridgeType: "OFT" }> => r.bridgeType === "OFT" && r.oft.token.toLowerCase() === lower
-  );
-  const oftAddr = (oft as any)?.oft?.oft?.[chain] as string | undefined;
-  if (oftAddr) {
-    return oftAddr;
-  }
-
   const hwr = reg.routes.find(
     (r): r is Extract<RouteConfig, { bridgeType: "HWR" }> => r.bridgeType === "HWR" && r.hwr.token.toLowerCase() === lower
   );
   if (hwr) {
+    const balancesAddr = (hwr as any)?.hwr?.balances?.[chain] as string | undefined;
+    if (balancesAddr) return balancesAddr;
+
     if (chain === "optimism") {
       const synth = (hwr as any)?.hwr?.syntheticToken?.optimism as string | undefined;
       if (synth) return synth;
     }
     const coll = (hwr as any)?.hwr?.collateralTokens?.[chain] as string | undefined;
     if (coll) return coll;
+  }
+
+  const oft = reg.routes.find(
+    (r): r is Extract<RouteConfig, { bridgeType: "OFT" }> => r.bridgeType === "OFT" && r.oft.token.toLowerCase() === lower
+  );
+  const oftAddr = (oft as any)?.oft?.oft?.[chain] as string | undefined;
+  if (oftAddr) {
+    return oftAddr;
   }
 
   return null;


### PR DESCRIPTION
# bridge-ui: Add dedicated balances field and resolve balances to ERC20 contracts

## Summary

This PR fixes the "Balance: —" issue on all chains (ETH, ARB, OP) by adding a dedicated `balances` field to route configurations and updating the token address resolver to use ERC20 token contracts for balance reads instead of OFT adapters or router contracts.

**Root cause**: The resolver was preferring LayerZero OFT adapter addresses on ETH/ARB and Hyperlane router addresses on OP for balance reads. Since these contracts don't implement ERC20 `balanceOf`, the reads returned no data, displaying "—".

**Solution**: 
- Added optional `balances?: Record<ChainKey, string | undefined>` to `HwrTopology` and `OftRoute` types
- Populated the registry with explicit ERC20 token contract addresses for PYUSD balance reads
- Updated `getTokenAddressForBalance` to prefer the `balances` field first, then fallback to existing HWR logic
- Moved OFT adapter lookup to last priority to avoid using non-ERC20 contracts for balances

## Review & Testing Checklist for Human

- [ ] **Critical**: Test balance display with connected wallet on all three chains (ETH, ARB, OP) - verify numeric balances show instead of "—"
- [ ] **Critical**: Verify the ERC20 addresses in the registry are correct token contracts (not accidentally router/adapter addresses)
- [ ] **Important**: Test existing bridge functionality still works (OFT transfers, HWR transfers) to ensure no regressions from resolver precedence changes
- [ ] **Important**: Check TypeScript compilation and verify no type errors with the new `balances` field
- [ ] **Medium**: Test that other UI flows using token addresses still work correctly (amount validation, token selection, etc.)

**Recommended test plan**: Connect wallet, switch between ETH/ARB/OP origins, verify balance shows numeric value, attempt a small bridge transaction to verify core functionality still works.

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    BalanceBadge["src/components/BalanceBadge.tsx"]:::context --> getTokenAddressForBalance["src/lib/tokenAddressResolver.ts"]:::major-edit
    BridgeSelector["src/components/BridgeSelector.tsx"]:::context --> getTokenAddressForBalance
    
    getTokenAddressForBalance --> Registry["public/registry.artifact.json"]:::major-edit
    getTokenAddressForBalance --> Types["src/config/types.ts"]:::minor-edit
    
    Registry --> HWRRoute["HWR Route<br/>+ balances field"]:::major-edit
    Registry --> OFTRoute["OFT Route<br/>+ balances field"]:::minor-edit
    
    getTokenAddressForBalance --> BalanceReadLogic["New Logic:<br/>1. balances[chain]<br/>2. HWR ERC20s<br/>3. OFT adapters"]:::major-edit
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end

    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB  
    classDef context fill:#FFFFFF
```

### Notes

This change isolates balance reads to a dedicated field while preserving existing OFT adapter and HWR router usage for bridge operations. The resolver precedence change should not affect bridge functionality since those flows likely use different address resolution paths.

**Link to Devin run**: https://app.devin.ai/sessions/7e92d13eb42347ec873be999b2f4fa82
**Requested by**: @tiljrd

**Registry addresses added**:
- ETH: `0x6c3ea9036406852006290770BEdFcAbA0e23A0e8` 
- ARB: `0x46850aD61C2B7d64d08c9C754F45254596696984`
- OP: `0x2A0B01E072b3d68249A2b3666cB90585eC4bd79e`