### PR TITLE
Bridge UI: add ETA badges and move Note into Connection route collapsible (HWR+OFT); align HWR fields

### DIFF
--- a/bridge-ui/src/components/hwr/HwrTransferForm.tsx
+++ b/bridge-ui/src/components/hwr/HwrTransferForm.tsx
@@ -156,6 +156,15 @@ export default function HwrTransferForm({
             <div className="text-sm">{amount || "0"}</div>
           </div>
         </div>
+        <div className="mt-3 space-y-2">
+          <label className="text-xs text-gray-500">Note (optional)</label>
+          <input
+            className="w-full rounded-xl border px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-gray-900/10"
+            placeholder="Add a note for your records"
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+          />
+        </div>
       </Collapsible>
 
       {!edgesOk && (
@@ -164,20 +173,12 @@ export default function HwrTransferForm({
         </div>
       )}
 
-      <div className="space-y-2">
-        <label className="text-xs text-gray-500">Note (optional)</label>
-        <input
-          className="w-full rounded-xl border px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-gray-900/10"
-          placeholder="Add a note for your records"
-          value={note}
-          onChange={(e) => setNote(e.target.value)}
-        />
-      </div>
 
-      <button
-        disabled={!edgesOk || busy}
-        className="w-full rounded-xl bg-gray-900 px-4 py-2.5 text-sm text-white disabled:opacity-50"
-        onClick={async () => {
+      <div className="flex items-center justify-between">
+        <button
+          disabled={!edgesOk || busy}
+          className="rounded-xl bg-gray-900 px-4 py-2.5 text-sm text-white disabled:opacity-50"
+          onClick={async () => {
           if (!edgesOk) {
             toast.error("No valid HWR edge for this route");
             return;
@@ -209,10 +210,15 @@ export default function HwrTransferForm({
           } finally {
             setBusy(false);
           }
-        }}
-      >
-        {busy ? "Submitting…" : "Submit normal transfer"}
-      </button>
+          }}
+        >
+          {busy ? "Submitting…" : "Submit normal transfer"}
+        </button>
+        <div className="flex items-center gap-1 text-[11px] text-gray-600">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" className="opacity-80"><path d="M12 8v5l4 2" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/><path d="M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" stroke="currentColor" strokeWidth="2"/></svg>
+          <span>3m</span>
+        </div>
+      </div>
 
       <Collapsible title="Fast transfer parameters" subtitle="Configure solver intent" defaultOpen={false}>
         <div className="space-y-3">
@@ -270,13 +276,19 @@ export default function HwrTransferForm({
         </div>
       </Collapsible>
 
-      <button
-        disabled={!edgesOk}
-        className="w-full rounded-xl bg-brand-700 hover:bg-brand-800 px-4 py-2.5 text-sm text-white disabled:opacity-50"
-        onClick={handleFastSubmit}
-      >
-        Submit Fast Transfer
-      </button>
+      <div className="flex items-center justify-between">
+        <button
+          disabled={!edgesOk}
+          className="rounded-xl bg-brand-700 hover:bg-brand-800 px-4 py-2.5 text-sm text-white disabled:opacity-50"
+          onClick={handleFastSubmit}
+        >
+          Submit Fast Transfer
+        </button>
+        <div className="flex items-center gap-1 text-[11px] text-gray-600">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" className="opacity-80"><path d="M12 8v5l4 2" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/><path d="M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" stroke="currentColor" strokeWidth="2"/></svg>
+          <span>20s</span>
+        </div>
+      </div>
     </div>
   );
 }

--- a/bridge-ui/src/components/hwr/HwrTransferForm.tsx
+++ b/bridge-ui/src/components/hwr/HwrTransferForm.tsx
@@ -214,7 +214,7 @@ export default function HwrTransferForm({
         >
           {busy ? "Submitting…" : "Submit normal transfer"}
         </button>
-        <div className="flex items-center gap-1 text-[11px] text-gray-600">
+        <div className="inline-flex items-center gap-1 text-[11px] text-gray-600 leading-none relative top-[2px]">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" className="opacity-80"><path d="M12 8v5l4 2" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/><path d="M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" stroke="currentColor" strokeWidth="2"/></svg>
           <span>3m</span>
         </div>
@@ -284,7 +284,7 @@ export default function HwrTransferForm({
         >
           Submit Fast Transfer
         </button>
-        <div className="flex items-center gap-1 text-[11px] text-gray-600">
+        <div className="inline-flex items-center gap-1 text-[11px] text-gray-600 leading-none relative top-[2px]">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" className="opacity-80"><path d="M12 8v5l4 2" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/><path d="M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" stroke="currentColor" strokeWidth="2"/></svg>
           <span>20s</span>
         </div>

--- a/bridge-ui/src/components/hwr/HwrTransferForm.tsx
+++ b/bridge-ui/src/components/hwr/HwrTransferForm.tsx
@@ -174,7 +174,7 @@ export default function HwrTransferForm({
       )}
 
 
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between -mt-1">
         <button
           disabled={!edgesOk || busy}
           className="rounded-xl bg-gray-900 px-4 py-2.5 text-sm text-white disabled:opacity-50"
@@ -214,7 +214,7 @@ export default function HwrTransferForm({
         >
           {busy ? "Submitting…" : "Submit normal transfer"}
         </button>
-        <div className="inline-flex items-center gap-1 text-[11px] text-gray-600 leading-none relative top-[2px]">
+        <div className="inline-flex items-center gap-1 text-[11px] text-gray-600 leading-none relative top-[3px]">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" className="opacity-80"><path d="M12 8v5l4 2" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/><path d="M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" stroke="currentColor" strokeWidth="2"/></svg>
           <span>3m</span>
         </div>
@@ -276,7 +276,7 @@ export default function HwrTransferForm({
         </div>
       </Collapsible>
 
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between -mt-1">
         <button
           disabled={!edgesOk}
           className="rounded-xl bg-brand-700 hover:bg-brand-800 px-4 py-2.5 text-sm text-white disabled:opacity-50"
@@ -284,7 +284,7 @@ export default function HwrTransferForm({
         >
           Submit Fast Transfer
         </button>
-        <div className="inline-flex items-center gap-1 text-[11px] text-gray-600 leading-none relative top-[2px]">
+        <div className="inline-flex items-center gap-1 text-[11px] text-gray-600 leading-none relative top-[3px]">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" className="opacity-80"><path d="M12 8v5l4 2" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/><path d="M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" stroke="currentColor" strokeWidth="2"/></svg>
           <span>20s</span>
         </div>

--- a/bridge-ui/src/components/oft/OftTransferForm.tsx
+++ b/bridge-ui/src/components/oft/OftTransferForm.tsx
@@ -33,6 +33,7 @@ export default function OftTransferForm({
   const { data: walletClient } = useWalletClient();
   const [busy, setBusy] = useState(false);
 
+  const [note, setNote] = useState<string>("");
   const [settlementAddress, setSettlementAddress] = useState<string>("");
   const [destinationAddress, setDestinationAddress] = useState<string>("");
   const [minOut, setMinOut] = useState<string>("");
@@ -143,16 +144,26 @@ export default function OftTransferForm({
           <div>Route: {origin} -&gt; {destination}</div>
           <div>Amount: {amount || "0"}</div>
         </div>
+        <div className="mt-3 space-y-2">
+          <label className="text-xs text-gray-500">Note (optional)</label>
+          <input
+            className="w-full rounded-xl border px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-gray-900/10"
+            placeholder="Add a note for your records"
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+          />
+        </div>
       </Collapsible>
 
-      <button
-        disabled={busy}
-        className={clsx(
-          "w-full rounded-xl px-4 py-2.5 text-sm text-white",
-          busy ? "bg-gray-700" : "bg-gray-900",
-          busy && "opacity-50"
-        )}
-        onClick={async () => {
+      <div className="flex items-center justify-between">
+        <button
+          disabled={busy}
+          className={clsx(
+            "rounded-xl px-4 py-2.5 text-sm text-white",
+            busy ? "bg-gray-700" : "bg-gray-900",
+            busy && "opacity-50"
+          )}
+          onClick={async () => {
           try {
             setBusy(true);
             let client = walletClient;
@@ -189,10 +200,15 @@ export default function OftTransferForm({
           } finally {
             setBusy(false);
           }
-        }}
-      >
-        Submit normal transfer
-      </button>
+          }}
+        >
+          Submit normal transfer
+        </button>
+        <div className="flex items-center gap-1 text-[11px] text-gray-600">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" className="opacity-80"><path d="M12 8v5l4 2" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/><path d="M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" stroke="currentColor" strokeWidth="2"/></svg>
+          <span>3m</span>
+        </div>
+      </div>
 
       <Collapsible title="Fast transfer parameters" subtitle="Configure solver intent" defaultOpen={false}>
         <div className="space-y-3">
@@ -251,12 +267,18 @@ export default function OftTransferForm({
         </div>
       </Collapsible>
 
-      <button
-        className="w-full rounded-xl bg-brand-700 hover:bg-brand-800 px-4 py-2.5 text-sm text-white"
-        onClick={handleFastSubmit}
-      >
-        Submit Fast Transfer
-      </button>
+      <div className="flex items-center justify-between">
+        <button
+          className="rounded-xl bg-brand-700 hover:bg-brand-800 px-4 py-2.5 text-sm text-white"
+          onClick={handleFastSubmit}
+        >
+          Submit Fast Transfer
+        </button>
+        <div className="flex items-center gap-1 text-[11px] text-gray-600">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" className="opacity-80"><path d="M12 8v5l4 2" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/><path d="M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" stroke="currentColor" strokeWidth="2"/></svg>
+          <span>20s</span>
+        </div>
+      </div>
     </div>
   );
 }

--- a/bridge-ui/src/components/oft/OftTransferForm.tsx
+++ b/bridge-ui/src/components/oft/OftTransferForm.tsx
@@ -204,7 +204,7 @@ export default function OftTransferForm({
         >
           Submit normal transfer
         </button>
-        <div className="flex items-center gap-1 text-[11px] text-gray-600">
+        <div className="inline-flex items-center gap-1 text-[11px] text-gray-600 leading-none relative top-[2px]">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" className="opacity-80"><path d="M12 8v5l4 2" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/><path d="M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" stroke="currentColor" strokeWidth="2"/></svg>
           <span>3m</span>
         </div>
@@ -274,7 +274,7 @@ export default function OftTransferForm({
         >
           Submit Fast Transfer
         </button>
-        <div className="flex items-center gap-1 text-[11px] text-gray-600">
+        <div className="inline-flex items-center gap-1 text-[11px] text-gray-600 leading-none relative top-[2px]">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" className="opacity-80"><path d="M12 8v5l4 2" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/><path d="M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" stroke="currentColor" strokeWidth="2"/></svg>
           <span>20s</span>
         </div>

--- a/bridge-ui/src/components/oft/OftTransferForm.tsx
+++ b/bridge-ui/src/components/oft/OftTransferForm.tsx
@@ -155,7 +155,7 @@ export default function OftTransferForm({
         </div>
       </Collapsible>
 
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between -mt-1">
         <button
           disabled={busy}
           className={clsx(
@@ -204,7 +204,7 @@ export default function OftTransferForm({
         >
           Submit normal transfer
         </button>
-        <div className="inline-flex items-center gap-1 text-[11px] text-gray-600 leading-none relative top-[2px]">
+        <div className="inline-flex items-center gap-1 text-[11px] text-gray-600 leading-none relative top-[3px]">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" className="opacity-80"><path d="M12 8v5l4 2" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/><path d="M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" stroke="currentColor" strokeWidth="2"/></svg>
           <span>3m</span>
         </div>
@@ -267,14 +267,14 @@ export default function OftTransferForm({
         </div>
       </Collapsible>
 
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between -mt-1">
         <button
           className="rounded-xl bg-brand-700 hover:bg-brand-800 px-4 py-2.5 text-sm text-white"
           onClick={handleFastSubmit}
         >
           Submit Fast Transfer
         </button>
-        <div className="inline-flex items-center gap-1 text-[11px] text-gray-600 leading-none relative top-[2px]">
+        <div className="inline-flex items-center gap-1 text-[11px] text-gray-600 leading-none relative top-[3px]">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" className="opacity-80"><path d="M12 8v5l4 2" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/><path d="M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" stroke="currentColor" strokeWidth="2"/></svg>
           <span>20s</span>
         </div>


### PR DESCRIPTION
# Bridge UI: add ETA badges and move Note into Connection route collapsible

## Summary

This PR implements UI polish requested by @tiljrd to improve the Step 2 bridge interface:

1. **ETA Badges**: Added small clock icons with estimated time next to submit buttons
   - "Submit normal transfer": 3m 
   - "Submit Fast Transfer": 20s
2. **Note Field Relocation**: Moved the "Note (optional)" input from standalone position into the Connection route collapsible section
3. **Layout Updates**: Changed buttons from full-width to flex layout to accommodate ETA badges

These changes apply to both Hyperlane HWR and LayerZero OFT Step 2 forms for consistency.

## Review & Testing Checklist for Human

- [ ] **Visual testing on mobile/tablet/desktop** - verify ETA badges and button layouts don't break on different screen sizes
- [ ] **Note field functionality** - confirm the note input works correctly inside the Connection route collapsible and is discoverable by users  
- [ ] **End-to-end flow testing** - test both HWR and OFT bridge flows from Step 1 → Step 2 → submission to ensure no regressions
- [ ] **ETA badge accuracy** - consider whether hardcoded times (3m/20s) should be made configurable or reflect real performance metrics

**Recommended test plan**: Navigate through both bridge flows (HWR: ethereum→optimism, OFT: ethereum→arbitrum), expand collapsibles, enter notes, and verify submit buttons work correctly.

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    Step1["Bridge Step 1<br/>(Route Selection)"] --> HWR["HwrTransferForm.tsx"]:::major-edit
    Step1 --> OFT["OftTransferForm.tsx"]:::major-edit
    
    HWR --> CollapsibleHWR["Connection Route<br/>Collapsible + Note"]
    HWR --> ButtonsHWR["Submit Buttons<br/>+ ETA Badges"]
    
    OFT --> CollapsibleOFT["Connection Route<br/>Collapsible + Note"] 
    OFT --> ButtonsOFT["Submit Buttons<br/>+ ETA Badges"]

    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit
        L3["Context/No Edit"]:::context
    end

    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB  
    classDef context fill:#FFFFFF
```

### Notes

- ETA values are currently hardcoded placeholders - may want to make configurable in future
- Button layout change from full-width to flex could potentially affect mobile UX
- This builds on the existing fast transfer UI work from PR #15

**Devin Session**: https://app.devin.ai/sessions/ac68430f984f4cecbe3d1c0e0524b003  
**Requested by**: @tiljrd