### PR TITLE
Fix: inline NEXT_PUBLIC_INPUT_SETTLER_* so Next.js bundles envs (fast intent)

### DIFF
--- a/bridge-ui/src/lib/fastIntent.ts
+++ b/bridge-ui/src/lib/fastIntent.ts
@@ -104,9 +104,15 @@ export const INPUT_SETTLER_ABI = [
   }
 ] as const;
 
+const INPUT_SETTLERS_STATIC: Partial<Record<ChainKey, string | undefined>> = {
+  ethereum: (typeof process !== "undefined" ? (process as any).env?.NEXT_PUBLIC_INPUT_SETTLER_ETHEREUM : undefined),
+  arbitrum: (typeof process !== "undefined" ? (process as any).env?.NEXT_PUBLIC_INPUT_SETTLER_ARBITRUM : undefined),
+  optimism: (typeof process !== "undefined" ? (process as any).env?.NEXT_PUBLIC_INPUT_SETTLER_OPTIMISM : undefined),
+  base: (typeof process !== "undefined" ? (process as any).env?.NEXT_PUBLIC_INPUT_SETTLER_BASE : undefined),
+};
+
 export function getInputSettlerAddress(origin: ChainKey): `0x${string}` | undefined {
-  const envKey = `NEXT_PUBLIC_INPUT_SETTLER_${origin.toUpperCase()}`;
-  const val = (typeof process !== "undefined" ? (process as any).env?.[envKey] : undefined) as string | undefined;
+  const val = INPUT_SETTLERS_STATIC[origin];
   return val ? (getAddress(val) as `0x${string}`) : undefined;
 }
 


### PR DESCRIPTION
# Fix: inline NEXT_PUBLIC_INPUT_SETTLER_* so Next.js bundles envs (fast intent)

## Summary

Fixes a critical bug where fast transfer intent submission was failing with "Missing input settler for ethereum" error even when environment variables were correctly set. 

The issue was that Next.js won't inline `NEXT_PUBLIC_*` environment variables into the client bundle when accessed dynamically via `process.env[dynamicKey]`. This PR replaces the dynamic access pattern with static references so Next.js can detect and inline the environment variables at build time.

**Before:**
```typescript
const envKey = `NEXT_PUBLIC_INPUT_SETTLER_${origin.toUpperCase()}`;
const val = process.env?.[envKey]; // ❌ Not inlined by Next.js
```

**After:**
```typescript
const INPUT_SETTLERS_STATIC = {
  ethereum: process.env.NEXT_PUBLIC_INPUT_SETTLER_ETHEREUM, // ✅ Inlined by Next.js
  arbitrum: process.env.NEXT_PUBLIC_INPUT_SETTLER_ARBITRUM,
  // ...
};
```

## Review & Testing Checklist for Human

- [ ] **Verify environment variable loading works** - Set the INPUT_SETTLER env vars in `bridge-ui/.env.local`, restart the app, and confirm the "Missing input settler" error is gone when trying fast transfer
- [ ] **Test complete fast transfer flow** - With real InputSettlerEscrow contract addresses, verify both ERC20 approval and openIntent transactions execute successfully  
- [ ] **Check for other dynamic env access patterns** - Search codebase for similar `process.env[dynamicKey]` patterns that might have the same Next.js bundling issue
- [ ] **Validate supported chains** - Confirm the hardcoded chains (ethereum, arbitrum, optimism, base) match your deployment expectations

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    UserEnvFile[".env.local<br/>NEXT_PUBLIC_INPUT_SETTLER_*"]:::context
    FastIntentLib["fastIntent.ts<br/>getInputSettlerAddress()"]:::major-edit
    HwrForm["HwrTransferForm.tsx<br/>handleFastSubmit()"]:::context
    OftForm["OftTransferForm.tsx<br/>handleFastSubmit()"]:::context
    NextJSBundle["Next.js Client Bundle<br/>(browser)"]:::context
    
    UserEnvFile -->|"statically referenced"| FastIntentLib
    FastIntentLib -->|"provides settler address"| HwrForm
    FastIntentLib -->|"provides settler address"| OftForm
    FastIntentLib -->|"bundled at build time"| NextJSBundle
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end

    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

- **Breaking change for dev workflow**: Developers must restart their dev server after this change for environment variables to be properly inlined
- **Chain support limitation**: The static map only supports ethereum, arbitrum, optimism, and base. Adding new chains requires updating the `INPUT_SETTLERS_STATIC` object
- **Next.js bundling behavior**: This fix exploits Next.js's static analysis to ensure environment variables are available in the client bundle, which is critical for blockchain contract interactions

**Requested by**: Til Jordan (@tiljrd)  
**Link to Devin run**: https://app.devin.ai/sessions/ac68430f984f4cecbe3d1c0e0524b003