### PR TITLE
fix(lib): viem encodeAbiParameters outputs tuple uses components schema

### DIFF
--- a/bridge-ui/src/lib/fastIntent.ts
+++ b/bridge-ui/src/lib/fastIntent.ts
@@ -139,7 +139,17 @@ function encodeStandardOrder(params: {
           { name: "inputs", type: "uint256[2][]" },
           {
             name: "outputs",
-            type: "tuple(bytes32 oracle, bytes32 settler, uint256 chainId, bytes32 token, uint256 amount, bytes32 recipient, bytes call, bytes context)[]",
+            type: "tuple[]",
+            components: [
+              { name: "oracle", type: "bytes32" },
+              { name: "settler", type: "bytes32" },
+              { name: "chainId", type: "uint256" },
+              { name: "token", type: "bytes32" },
+              { name: "amount", type: "uint256" },
+              { name: "recipient", type: "bytes32" },
+              { name: "call", type: "bytes" },
+              { name: "context", type: "bytes" }
+            ],
           },
         ],
       } as const,


### PR DESCRIPTION
# fix(lib): viem encodeAbiParameters outputs tuple uses components schema

## Summary

Fixes a viem encoding error in `fastIntent.ts` where the StandardOrder outputs tuple was using a string-based type definition instead of the components-based schema required by viem v2.33.3. This was blocking fast transfer submissions with the error: `Type "tuple(...)" is not a valid encoding type`.

The change updates the `encodeAbiParameters` call to use `type: "tuple[]"` with explicit `components` array instead of the inline string tuple definition, ensuring proper ABI encoding for the InputSettlerEscrow.open() method.

## Review & Testing Checklist for Human

- [ ] **Test fast transfer end-to-end**: Try a fast transfer (e.g., ETH → ARB) and verify no encoding errors occur, wallet shows reasonable gas fees (~200-500k range unless approval is needed)
- [ ] **Verify settlement address embedding**: Confirm settlement address auto-fills from `NEXT_PUBLIC_OUTPUT_SETTLER_*` env vars and is correctly embedded in the encoded StandardOrder 
- [ ] **Check StandardOrder structure**: Ensure the encoded order structure (user, nonce, originChainId, expires, fillDeadline, inputOracle, inputs, outputs) matches what the InputSettlerEscrow contract expects
- [ ] **Test chain guard functionality**: Verify that submitting from wrong chain shows appropriate error rather than inflated gas estimates

**Recommended test plan**: Set up env vars for settlers/oracles, restart dev server, attempt fast transfer with sufficient token balance, and verify the transaction flow works without encoding errors.

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    User["User clicks<br/>Submit Fast Transfer"]
    HwrForm["HwrTransferForm.tsx<br/>(chain guard check)"]:::minor-edit
    OftForm["OftTransferForm.tsx<br/>(chain guard check)"]:::minor-edit
    FastIntent["fastIntent.ts<br/>(encodeStandardOrder)"]:::major-edit
    Viem["viem encodeAbiParameters<br/>(fixed components schema)"]
    Contract["InputSettlerEscrow.open()"]
    
    User --> HwrForm
    User --> OftForm
    HwrForm --> FastIntent
    OftForm --> FastIntent
    FastIntent --> Viem
    Viem --> Contract
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit
        L3[Context/No Edit]:::context
    end

    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

This fix is part of the larger fast transfer implementation that uses the StandardOrder structure to submit intents via InputSettlerEscrow. The settlement address is embedded as bytes32 in the outputs array rather than passed as a separate parameter.

**Link to Devin run**: https://app.devin.ai/sessions/ac68430f984f4cecbe3d1c0e0524b003  
**Requested by**: Til Jordan (@tiljrd)